### PR TITLE
Use default User model in core

### DIFF
--- a/dentisoft/core/admin.py
+++ b/dentisoft/core/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
 
-# Register your models here.

--- a/dentisoft/core/apps.py
+++ b/dentisoft/core/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class CoreConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'core'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "core"

--- a/dentisoft/core/tests.py
+++ b/dentisoft/core/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
 
-# Create your tests here.

--- a/dentisoft/core/views.py
+++ b/dentisoft/core/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
 
-# Create your views here.


### PR DESCRIPTION
## Summary
- remove custom `Usuario` model
- reference `settings.AUTH_USER_MODEL` where needed
- cleanup unused imports in the core app

## Testing
- `ruff check .`
- `pytest -q` *(fails: unrecognized arguments --ds=config.settings.test)*

------
https://chatgpt.com/codex/tasks/task_e_6840ca15e7e88320b8d33c009ebd232f