### PR TITLE
Extend custom user model with clinic and role

### DIFF
--- a/dentisoft/config/settings/base.py
+++ b/dentisoft/config/settings/base.py
@@ -87,6 +87,7 @@ THIRD_PARTY_APPS = [
 
 LOCAL_APPS = [
     "dentisoft.users",
+    "core",
     # Your stuff: custom apps go here
 ]
 # https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps

--- a/dentisoft/core/admin.py
+++ b/dentisoft/core/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
 
-# Register your models here.

--- a/dentisoft/core/apps.py
+++ b/dentisoft/core/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class CoreConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'core'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "core"

--- a/dentisoft/core/tests.py
+++ b/dentisoft/core/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
 
-# Create your tests here.

--- a/dentisoft/core/views.py
+++ b/dentisoft/core/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
 
-# Create your views here.

--- a/dentisoft/dentisoft/users/models.py
+++ b/dentisoft/dentisoft/users/models.py
@@ -2,10 +2,17 @@
 from typing import ClassVar
 
 from django.contrib.auth.models import AbstractUser
+from django.db.models import CASCADE
+from django.db.models import PROTECT
+from django.db.models import BooleanField
 from django.db.models import CharField
 from django.db.models import EmailField
+from django.db.models import ForeignKey
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+
+from dentisoft.core.models import Clinica
+from dentisoft.core.models import Rol
 
 from .managers import UserManager
 
@@ -23,6 +30,10 @@ class User(AbstractUser):
     last_name = None  # type: ignore[assignment]
     email = EmailField(_("email address"), unique=True)
     username = None  # type: ignore[assignment]
+
+    rol = ForeignKey(Rol, on_delete=PROTECT, null=True)
+    clinica = ForeignKey(Clinica, on_delete=CASCADE, null=True)
+    activo = BooleanField(default=True)
 
     USERNAME_FIELD = "email"
     REQUIRED_FIELDS = []

--- a/dentisoft/dentisoft/users/models.py
+++ b/dentisoft/dentisoft/users/models.py
@@ -11,8 +11,8 @@ from django.db.models import ForeignKey
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from dentisoft.core.models import Clinica
-from dentisoft.core.models import Rol
+from core.models import Clinica
+from core.models import Rol
 
 from .managers import UserManager
 


### PR DESCRIPTION
## Summary
- add `rol`, `clinica`, and `activo` fields to the custom `User` model

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840ca15e7e88320b8d33c009ebd232f