### PR TITLE
Add invite API endpoints and email tasks

### DIFF
--- a/dentisoft/config/api_router.py
+++ b/dentisoft/config/api_router.py
@@ -3,10 +3,12 @@ from rest_framework.routers import DefaultRouter
 from rest_framework.routers import SimpleRouter
 
 from dentisoft.users.api.views import UserViewSet
+from core.api.views import InvitacionUsuarioViewSet
 
 router = DefaultRouter() if settings.DEBUG else SimpleRouter()
 
 router.register("users", UserViewSet)
+router.register("invitaciones", InvitacionUsuarioViewSet)
 
 
 app_name = "api"

--- a/dentisoft/config/urls.py
+++ b/dentisoft/config/urls.py
@@ -10,6 +10,8 @@ from drf_spectacular.views import SpectacularAPIView
 from drf_spectacular.views import SpectacularSwaggerView
 from rest_framework.authtoken.views import obtain_auth_token
 
+from core.api.views import InviteRegisterAPIView
+
 urlpatterns = [
     path("", TemplateView.as_view(template_name="pages/home.html"), name="home"),
     path(
@@ -37,6 +39,11 @@ urlpatterns += [
     path("api/", include("config.api_router")),
     # DRF auth token
     path("api/auth-token/", obtain_auth_token, name="obtain_auth_token"),
+    path(
+        "api/invite-register/",
+        InviteRegisterAPIView.as_view(),
+        name="invite-register",
+    ),
     path("api/schema/", SpectacularAPIView.as_view(), name="api-schema"),
     path(
         "api/docs/",

--- a/dentisoft/core/api/views.py
+++ b/dentisoft/core/api/views.py
@@ -1,0 +1,30 @@
+from rest_framework import status, viewsets
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from core.api.serializers import InvitacionUsuarioSerializer, InviteRegisterSerializer
+from core.models import InvitacionUsuario
+from core.tasks import enviar_invitacion_email
+
+
+class InvitacionUsuarioViewSet(viewsets.ModelViewSet):
+    queryset = InvitacionUsuario.objects.all()
+    serializer_class = InvitacionUsuarioSerializer
+
+    def create(self, request, *args, **kwargs):
+        data = request.data.copy()
+        data["invitado_por"] = request.user.pk
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        invitacion = serializer.save()
+        enviar_invitacion_email.delay(invitacion.id)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+
+class InviteRegisterAPIView(APIView):
+    def post(self, request):
+        serializer = InviteRegisterSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+        return Response({"id": user.id, "email": user.email}, status=status.HTTP_201_CREATED)

--- a/dentisoft/core/tasks.py
+++ b/dentisoft/core/tasks.py
@@ -1,0 +1,17 @@
+from celery import shared_task
+from django.core.mail import send_mail
+from django.urls import reverse
+
+from core.models import InvitacionUsuario
+
+
+@shared_task()
+def enviar_invitacion_email(invitacion_id: str) -> None:
+    invitacion = InvitacionUsuario.objects.get(id=invitacion_id)
+    subject = "Invitación a DentiSoft"
+    mensaje = (
+        "Has sido invitado a unirte a DentiSoft. "
+        f"Utiliza este token para registrarte: {invitacion.token}"
+    )
+    send_mail(subject, mensaje, None, [invitacion.email])
+


### PR DESCRIPTION
## Summary
- add invitation user API viewset and invite register view
- register new views in router and URL config
- implement async email task for invitations

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684a0df4c5c08320b10c3bc7c253aed7