### PR TITLE
Add email task and domain settings

### DIFF
--- a/dentisoft/config/settings/base.py
+++ b/dentisoft/config/settings/base.py
@@ -36,6 +36,7 @@ LANGUAGE_CODE = "en-us"
 # ]
 # https://docs.djangoproject.com/en/dev/ref/settings/#site-id
 SITE_ID = 1
+SITE_DOMAIN = env("DJANGO_SITE_DOMAIN", default="example.com")
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-i18n
 USE_I18N = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-tz

--- a/dentisoft/config/settings/local.py
+++ b/dentisoft/config/settings/local.py
@@ -15,6 +15,7 @@ SECRET_KEY = env(
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1"]  # noqa: S104
+SITE_DOMAIN = env("DJANGO_SITE_DOMAIN", default="localhost:8000")
 
 # CACHES
 # ------------------------------------------------------------------------------

--- a/dentisoft/config/settings/production.py
+++ b/dentisoft/config/settings/production.py
@@ -20,6 +20,7 @@ from .base import env
 SECRET_KEY = env("DJANGO_SECRET_KEY")
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["dentisoft.com"])
+SITE_DOMAIN = env("DJANGO_SITE_DOMAIN", default="dentisoft.com")
 
 # DATABASES
 # ------------------------------------------------------------------------------

--- a/dentisoft/config/settings/test.py
+++ b/dentisoft/config/settings/test.py
@@ -13,6 +13,7 @@ SECRET_KEY = env(
     "DJANGO_SECRET_KEY",
     default="FMf98tFc8zeXEGp4EWvDnbbSNuH98rfEkUNSyBIlzTjDRgRkpkarlhmEi5EmH1xW",
 )
+SITE_DOMAIN = env("DJANGO_SITE_DOMAIN", default="testserver")
 # https://docs.djangoproject.com/en/dev/ref/settings/#test-runner
 TEST_RUNNER = "django.test.runner.DiscoverRunner"
 

--- a/dentisoft/core/tasks.py
+++ b/dentisoft/core/tasks.py
@@ -1,0 +1,19 @@
+from celery import shared_task
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import render_to_string
+
+
+@shared_task()
+def send_test_email(recipient: str) -> bool:
+    """Send a test email with plain text and HTML versions."""
+    context = {"domain": settings.SITE_DOMAIN}
+    text_body = render_to_string("email/test_email.txt", context)
+    html_body = render_to_string("email/test_email.html", context)
+    message = EmailMultiAlternatives(
+        subject="Test Email", body=text_body, to=[recipient],
+    )
+    message.attach_alternative(html_body, "text/html")
+    message.send()
+    return True
+

--- a/dentisoft/core/tests/test_tasks.py
+++ b/dentisoft/core/tests/test_tasks.py
@@ -1,0 +1,23 @@
+import pytest
+from celery.result import EagerResult
+from django.core import mail
+
+from core.tasks import send_test_email
+
+pytestmark = pytest.mark.django_db
+
+
+def test_send_test_email(settings):
+    settings.CELERY_TASK_ALWAYS_EAGER = True
+    settings.SITE_DOMAIN = "example.com"
+    result = send_test_email.delay("test@example.com")
+    assert isinstance(result, EagerResult)
+    assert result.result is True
+    assert len(mail.outbox) == 1
+    message = mail.outbox[0]
+    assert message.to == ["test@example.com"]
+    assert message.body.strip() == "Hello from example.com!"
+    assert message.alternatives[0][0].strip() == (
+        "<p>Hello from <strong>example.com</strong>!</p>"
+    )
+

--- a/dentisoft/dentisoft/templates/email/test_email.html
+++ b/dentisoft/dentisoft/templates/email/test_email.html
@@ -1,0 +1,1 @@
+<p>Hello from <strong>{{ domain }}</strong>!</p>

--- a/dentisoft/dentisoft/templates/email/test_email.txt
+++ b/dentisoft/dentisoft/templates/email/test_email.txt
@@ -1,0 +1,1 @@
+Hello from {{ domain }}!


### PR DESCRIPTION
## Summary
- create Celery task for sending HTML and text emails
- store email templates in `templates/email/`
- define `SITE_DOMAIN` setting and wire into env configs
- test email task with Celery eager mode

## Testing
- `ruff check --fix dentisoft/core/tasks.py dentisoft/core/tests/test_tasks.py dentisoft/config/settings/base.py dentisoft/config/settings/local.py dentisoft/config/settings/production.py dentisoft/config/settings/test.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_684a3015c5688320ac996d2a2e6ca329