### PR TITLE
Add default email settings

### DIFF
--- a/dentisoft/config/settings/base.py
+++ b/dentisoft/config/settings/base.py
@@ -229,6 +229,8 @@ EMAIL_BACKEND = env(
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-timeout
 EMAIL_TIMEOUT = 5
+# https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email
+DEFAULT_FROM_EMAIL = f"DentiSoft <noreply@{SITE_DOMAIN}>"
 
 # ADMIN
 # ------------------------------------------------------------------------------

--- a/dentisoft/config/settings/production.py
+++ b/dentisoft/config/settings/production.py
@@ -118,7 +118,7 @@ MEDIA_URL = f"https://{aws_s3_domain}/media/"
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email
 DEFAULT_FROM_EMAIL = env(
     "DJANGO_DEFAULT_FROM_EMAIL",
-    default="DentiSoft <noreply@dentisoft.com>",
+    default=DEFAULT_FROM_EMAIL,
 )
 # https://docs.djangoproject.com/en/dev/ref/settings/#server-email
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)

--- a/dentisoft/core/tasks.py
+++ b/dentisoft/core/tasks.py
@@ -11,7 +11,10 @@ def send_test_email(recipient: str) -> bool:
     text_body = render_to_string("email/test_email.txt", context)
     html_body = render_to_string("email/test_email.html", context)
     message = EmailMultiAlternatives(
-        subject="Test Email", body=text_body, to=[recipient],
+        subject="Test Email",
+        body=text_body,
+        to=[recipient],
+        from_email=settings.DEFAULT_FROM_EMAIL,
     )
     message.attach_alternative(html_body, "text/html")
     message.send()


### PR DESCRIPTION
## Summary
- configure `DEFAULT_FROM_EMAIL` in base settings
- override `DEFAULT_FROM_EMAIL` in production using env vars
- ensure test email task sends from `settings.DEFAULT_FROM_EMAIL`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for celery and django)*

------
https://chatgpt.com/codex/tasks/task_e_684a34a0aacc83209b16da8e9c8ced58