### PR TITLE
Add invitation email task

### DIFF
--- a/dentisoft/core/tasks.py
+++ b/dentisoft/core/tasks.py
@@ -3,6 +3,9 @@ from celery import shared_task
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
+from django.utils.translation import gettext_lazy as _
+
+from core.models import InvitacionUsuario
 
 
 @shared_task()
@@ -15,6 +18,32 @@ def send_test_email(recipient: str) -> bool:
         subject="Test Email",
         body=text_body,
         to=[recipient],
+        from_email=settings.DEFAULT_FROM_EMAIL,
+    )
+    message.attach_alternative(html_body, "text/html")
+    message.send()
+    return True
+
+
+@shared_task()
+def enviar_invitacion_email(invitacion_id: str) -> bool:
+    """Send invitation email to the provided address."""
+    invitacion = InvitacionUsuario.objects.get(id=invitacion_id)
+    invitation_url = (
+        f"https://{settings.SITE_DOMAIN}/api/invite-register/?token="
+        f"{invitacion.token}"
+    )
+    context = {
+        "domain": settings.SITE_DOMAIN,
+        "invitation_url": invitation_url,
+        "expiration_date": invitacion.fecha_expiracion,
+    }
+    text_body = render_to_string("email/invitation_email.txt", context)
+    html_body = render_to_string("email/invitation_email.html", context)
+    message = EmailMultiAlternatives(
+        subject=_("Invitation to register"),
+        body=text_body,
+        to=[invitacion.email],
         from_email=settings.DEFAULT_FROM_EMAIL,
     )
     message.attach_alternative(html_body, "text/html")

--- a/dentisoft/core/tests/test_tasks.py
+++ b/dentisoft/core/tests/test_tasks.py
@@ -2,7 +2,10 @@ import pytest
 from celery.result import EagerResult
 from django.core import mail
 
-from core.tasks import send_test_email
+from django.utils import timezone
+
+from core.models import Clinica, InvitacionUsuario, Rol
+from core.tasks import enviar_invitacion_email, send_test_email
 
 pytestmark = pytest.mark.django_db
 
@@ -20,4 +23,35 @@ def test_send_test_email(settings):
     assert message.alternatives[0][0].strip() == (
         "<p>Hello from <strong>example.com</strong>!</p>"
     )
+
+
+def test_enviar_invitacion_email(settings, user):
+    settings.CELERY_TASK_ALWAYS_EAGER = True
+    settings.SITE_DOMAIN = "example.com"
+
+    rol = Rol.objects.create(nombre="Rol", descripcion="")
+    clinica = Clinica.objects.create(
+        nombre="Clinica",
+        direccion="Dir",
+        telefono="123",
+        email="c@example.com",
+    )
+    invitacion = InvitacionUsuario.objects.create(
+        email="invitee@example.com",
+        token="token123",
+        rol=rol,
+        clinica=clinica,
+        invitado_por=user,
+        fecha_expiracion=timezone.now(),
+    )
+
+    result = enviar_invitacion_email.delay(str(invitacion.id))
+    assert isinstance(result, EagerResult)
+    assert result.result is True
+    assert len(mail.outbox) == 1
+    message = mail.outbox[0]
+    url = f"https://example.com/api/invite-register/?token={invitacion.token}"
+    assert message.to == ["invitee@example.com"]
+    assert url in message.body
+    assert url in message.alternatives[0][0]
 

--- a/dentisoft/dentisoft/templates/email/invitation_email.html
+++ b/dentisoft/dentisoft/templates/email/invitation_email.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+<p>{% translate "You have been invited to join" %} <strong>{{ domain }}</strong>.</p>
+<p>{% translate "Use the following link to accept the invitation" %}:</p>
+<p><a href="{{ invitation_url }}">{{ invitation_url }}</a></p>
+<p>{% translate "This invitation expires on" %} {{ expiration_date }}.</p>

--- a/dentisoft/dentisoft/templates/email/invitation_email.txt
+++ b/dentisoft/dentisoft/templates/email/invitation_email.txt
@@ -1,0 +1,5 @@
+{% load i18n %}
+{% translate "You have been invited to join" %} {{ domain }}.
+{% translate "Use the following link to accept the invitation" %}:
+{{ invitation_url }}
+{% translate "This invitation expires on" %} {{ expiration_date }}.


### PR DESCRIPTION
## Summary
- create email templates for invitation
- add new Celery task `enviar_invitacion_email`
- test sending invitation emails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_684a390a15d08320bb81b7ccf3dea287