### PR TITLE
Fix core email tests missing user fixture

### DIFF
--- a/dentisoft/core/tests/conftest.py
+++ b/dentisoft/core/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from dentisoft.users.models import User
+from dentisoft.users.tests.factories import UserFactory
+
+@pytest.fixture(autouse=True)
+def _media_storage(settings, tmpdir) -> None:
+    settings.MEDIA_ROOT = tmpdir.strpath
+
+
+@pytest.fixture
+def user(db) -> User:
+    return UserFactory()


### PR DESCRIPTION
## Summary
- provide `user` fixture for core tests

## Testing
- `pytest core/tests/test_tasks.py -q` *(fails: ModuleNotFoundError: No module named 'dentisoft')*

------
https://chatgpt.com/codex/tasks/task_e_684b35b40d988320a129cbb6f6a0a02f