### PR TITLE
Enhance invitation registration flow

### DIFF
--- a/dentisoft/config/settings/base.py
+++ b/dentisoft/config/settings/base.py
@@ -361,5 +361,8 @@ SPECTACULAR_SETTINGS = {
     "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],
     "SCHEMA_PATH_PREFIX": "/api/",
 }
+# Additional custom settings
+RECAPTCHA_REQUIRED = env.bool("DJANGO_RECAPTCHA_REQUIRED", default=False)
+RECAPTCHA_SECRET_KEY = env("DJANGO_RECAPTCHA_SECRET_KEY", default="")
 # Your stuff...
 # ------------------------------------------------------------------------------

--- a/dentisoft/config/settings/local.py
+++ b/dentisoft/config/settings/local.py
@@ -17,6 +17,10 @@ SECRET_KEY = env(
 ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1"]  # noqa: S104
 SITE_DOMAIN = env("DJANGO_SITE_DOMAIN", default="localhost:8000")
 
+# Frontend dev server origins
+CORS_ALLOWED_ORIGINS = ["http://localhost:3000", "http://127.0.0.1:3000"]
+CSRF_TRUSTED_ORIGINS = ["http://localhost:3000", "http://127.0.0.1:3000"]
+
 # CACHES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#caches

--- a/dentisoft/core/api/serializers.py
+++ b/dentisoft/core/api/serializers.py
@@ -1,13 +1,41 @@
 # core/api/serializers.py
+import json
+import re
 import uuid
 from datetime import timedelta
+from urllib import parse
+from urllib import request
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db import transaction
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from core.models import InvitacionUsuario, Clinica, Rol
+from core.models import Clinica
+from core.models import InvitacionUsuario
+from core.models import Rol
+
+
+def verify_recaptcha(token: str) -> bool:
+    """Validate recaptcha token with Google."""
+    secret = getattr(settings, "RECAPTCHA_SECRET_KEY", "")
+    if not secret:
+        return False
+    data = parse.urlencode({"secret": secret, "response": token}).encode()
+    req = request.Request(
+        "https://www.google.com/recaptcha/api/siteverify",
+        data=data,
+        method="POST",
+    )
+    try:
+        with request.urlopen(req, timeout=5) as resp:  # noqa: S310
+            payload = json.loads(resp.read().decode())
+    except Exception:  # noqa: BLE001
+        return False
+    return bool(payload.get("success"))
+
 
 User = get_user_model()
 
@@ -49,12 +77,12 @@ class InvitacionUsuarioSerializer(serializers.ModelSerializer):
 
         try:
             rol = Rol.objects.get(pk=rol_id)
-        except Rol.DoesNotExist as exc:  # noqa: B904
+        except Rol.DoesNotExist as exc:
             raise ValidationError({"rol": "Rol inválido"}) from exc
 
         try:
             clinica = Clinica.objects.get(pk=clinica_id)
-        except Clinica.DoesNotExist as exc:  # noqa: B904
+        except Clinica.DoesNotExist as exc:
             raise ValidationError({"clinica": "Clínica inválida"}) from exc
 
         attrs["rol"] = rol
@@ -63,11 +91,11 @@ class InvitacionUsuarioSerializer(serializers.ModelSerializer):
         if (
             email
             and InvitacionUsuario.objects.filter(
-                email=email, clinica=clinica, estado="pendiente"
+                email=email, clinica=clinica, estado="pendiente",
             ).exists()
         ):
             raise ValidationError("Ya existe una invitación pendiente para este correo")
-        
+
         if request:
             if getattr(request.user, "clinica_id", None) != clinica.id:
                 raise ValidationError({"clinica": "Clínica inválida para este usuario"})
@@ -90,17 +118,18 @@ class InvitacionUsuarioSerializer(serializers.ModelSerializer):
 
 
 class InviteRegisterSerializer(serializers.Serializer):
-    """
-    Serializer para registrar un User a partir de un token de invitación.
-    """
+    """Serializer para registrar un ``User`` desde una invitación."""
+
     token = serializers.CharField()
     first_name = serializers.CharField(max_length=30)
     last_name = serializers.CharField(max_length=150)
     email = serializers.EmailField()
-    password = serializers.CharField(write_only=True)
+    password1 = serializers.CharField(write_only=True)
+    password2 = serializers.CharField(write_only=True)
     telefono = serializers.CharField(max_length=20)
     fecha_nacimiento = serializers.DateField()
     genero = serializers.ChoiceField(choices=User._meta.get_field("genero").choices)
+    recaptcha = serializers.CharField(write_only=True, required=False)
     def validate_token(self, value):
         try:
             inv = InvitacionUsuario.objects.get(token=value, estado="pendiente")
@@ -114,21 +143,48 @@ class InviteRegisterSerializer(serializers.Serializer):
 
         return inv
 
+    def validate(self, attrs):
+        inv = attrs.get("token")
+        if attrs.get("email") != inv.email:
+            raise ValidationError({"email": "El email no coincide con la invitación"})
+
+        if User.objects.filter(email=attrs["email"]).exists():
+            raise ValidationError({"email": "Este correo ya está registrado"})
+
+        if User.objects.filter(telefono=attrs["telefono"]).exists():
+            raise ValidationError({"telefono": "Este teléfono ya está registrado"})
+
+        password = attrs.get("password1")
+        if password != attrs.get("password2"):
+            raise ValidationError({"password2": "Las contraseñas no coinciden"})
+
+        if len(password) < 8 or not re.search(r"[A-Z]", password) or not re.search(r"[0-9!@#$%^&*()_+=\-]", password):
+            raise ValidationError({"password1": "La contraseña no cumple la política"})
+
+        if getattr(settings, "RECAPTCHA_REQUIRED", False):
+            token = attrs.get("recaptcha")
+            if not token or not verify_recaptcha(token):
+                raise ValidationError({"recaptcha": "ReCaptcha inválido"})
+
+        return attrs
+
     def create(self, validated_data):
         inv = validated_data.pop("token")
-        # Crear el usuario con los datos de la invitación
-        user = User.objects.create_user(
-            email=validated_data["email"],
-            password=validated_data["password"],
-            first_name=validated_data["first_name"],
-            last_name=validated_data["last_name"],
-            telefono=validated_data["telefono"],
-            fecha_nacimiento=validated_data["fecha_nacimiento"],
-            genero=validated_data["genero"],
-            rol=inv.rol,
-            clinica=inv.clinica,
-        )
-        # Marcar invitación como usada
-        inv.estado = "usada"
-        inv.save()
+        validated_data.pop("password2")
+        validated_data.pop("recaptcha", None)
+        password = validated_data.pop("password1")
+        with transaction.atomic():
+            user = User.objects.create_user(
+                email=validated_data["email"],
+                password=password,
+                first_name=validated_data["first_name"],
+                last_name=validated_data["last_name"],
+                telefono=validated_data["telefono"],
+                fecha_nacimiento=validated_data["fecha_nacimiento"],
+                genero=validated_data["genero"],
+                rol=inv.rol,
+                clinica=inv.clinica,
+            )
+            inv.estado = "usada"
+            inv.save()
         return user

--- a/dentisoft/core/tests/test_invitation_api.py
+++ b/dentisoft/core/tests/test_invitation_api.py
@@ -1,12 +1,15 @@
-import pytest
 import logging
 import uuid
+
+import pytest
 from django.urls import reverse
 from django.utils import timezone
 
-from core.models import Clinica, Rol, InvitacionUsuario
-from dentisoft.users.models import User
 from core.api.permissions import CanInvitePermission
+from core.models import Clinica
+from core.models import InvitacionUsuario
+from core.models import Rol
+from dentisoft.users.models import User
 
 pytestmark = pytest.mark.django_db
 
@@ -68,7 +71,8 @@ def test_invite_register_creates_user(client):
         "first_name": "New",
         "last_name": "User",
         "email": invitacion.email,
-        "password": "pass1234",
+        "password1": "Pass1234",
+        "password2": "Pass1234",
         "telefono": "1234567",
         "fecha_nacimiento": timezone.now().date(),
         "genero": "M",
@@ -85,13 +89,138 @@ def test_invite_register_creates_user(client):
     assert user.clinica == clinica
 
 
+def test_invite_register_email_mismatch(client):
+    """Registration fails if provided email doesn't match invitation."""
+    rol, clinica = create_clinica_and_rol()
+    invitacion = InvitacionUsuario.objects.create(
+        email="new2@example.com",
+        token="token456",
+        rol=rol,
+        clinica=clinica,
+        fecha_expiracion=timezone.now() + timezone.timedelta(days=1),
+    )
+    data = {
+        "token": invitacion.token,
+        "first_name": "New",
+        "last_name": "User",
+        "email": "wrong@example.com",
+        "password1": "Pass1234",
+        "password2": "Pass1234",
+        "telefono": "1111",
+        "fecha_nacimiento": timezone.now().date(),
+        "genero": "M",
+    }
+    url = reverse("invite-register")
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert "email" in response.json()
+
+
+def test_invite_register_unique_phone(client):
+    """Registration fails if phone already exists."""
+    rol, clinica = create_clinica_and_rol()
+    InvitacionUsuario.objects.create(
+        email="dup@example.com",
+        token="token789",
+        rol=rol,
+        clinica=clinica,
+        fecha_expiracion=timezone.now() + timezone.timedelta(days=1),
+    )
+    User.objects.create_user(
+        email="other@example.com",
+        password="pass",
+        first_name="A",
+        last_name="B",
+        telefono="9999",
+        fecha_nacimiento=timezone.now().date(),
+        genero="M",
+        rol=rol,
+        clinica=clinica,
+    )
+    data = {
+        "token": "token789",
+        "first_name": "Foo",
+        "last_name": "Bar",
+        "email": "dup@example.com",
+        "password1": "Pass1234",
+        "password2": "Pass1234",
+        "telefono": "9999",
+        "fecha_nacimiento": timezone.now().date(),
+        "genero": "M",
+    }
+    url = reverse("invite-register")
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert "telefono" in response.json()
+
+
+def test_invite_register_password_policy(client):
+    rol, clinica = create_clinica_and_rol()
+    invitacion = InvitacionUsuario.objects.create(
+        email="policy@example.com",
+        token="tokpol",
+        rol=rol,
+        clinica=clinica,
+        fecha_expiracion=timezone.now() + timezone.timedelta(days=1),
+    )
+    data = {
+        "token": invitacion.token,
+        "first_name": "N",
+        "last_name": "U",
+        "email": invitacion.email,
+        "password1": "short",
+        "password2": "short",
+        "telefono": "1234",
+        "fecha_nacimiento": timezone.now().date(),
+        "genero": "M",
+    }
+    url = reverse("invite-register")
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert "password1" in response.json()
+
+
+def test_invite_register_recaptcha_required(client, settings, monkeypatch):
+    rol, clinica = create_clinica_and_rol()
+    invitacion = InvitacionUsuario.objects.create(
+        email="bot@example.com",
+        token="tokcap",
+        rol=rol,
+        clinica=clinica,
+        fecha_expiracion=timezone.now() + timezone.timedelta(days=1),
+    )
+    settings.RECAPTCHA_REQUIRED = True
+    monkeypatch.setattr("core.api.serializers.verify_recaptcha", lambda t: False)
+    data = {
+        "token": invitacion.token,
+        "first_name": "B",
+        "last_name": "O",
+        "email": invitacion.email,
+        "password1": "Pass1234",
+        "password2": "Pass1234",
+        "telefono": "123",
+        "fecha_nacimiento": timezone.now().date(),
+        "genero": "M",
+        "recaptcha": "token",
+    }
+    url = reverse("invite-register")
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert "recaptcha" in response.json()
+
+
 def test_invite_register_invalid_token(client):
     data = {
         "token": "invalid",
         "first_name": "Bad",
         "last_name": "Guy",
         "email": "bad@example.com",
-        "password": "pass",
+        "password1": "Pass1234",
+        "password2": "Pass1234",
         "telefono": "1234567",
         "fecha_nacimiento": timezone.now().date(),
         "genero": "M",
@@ -160,7 +289,7 @@ def test_invite_with_nonexistent_role(client):
 def test_invite_to_other_clinic(client):
     rol, clinica = create_clinica_and_rol()
     other_clinic = Clinica.objects.create(
-        nombre="Otra", direccion="Dir", telefono="123", email="o@example.com"
+        nombre="Otra", direccion="Dir", telefono="123", email="o@example.com",
     )
     user = create_user_with_role_clinic(rol, clinica, email="user2@example.com")
     client.force_login(user)
@@ -179,7 +308,7 @@ def test_non_cca_invites_cca(client):
     rol_user = Rol.objects.create(nombre="dentista", descripcion="")
     rol_cca, _ = Rol.objects.get_or_create(nombre="CCA", defaults={"descripcion": ""})
     clinica = Clinica.objects.create(
-        nombre="Clinica1", direccion="Dir", telefono="123", email="c1@example.com"
+        nombre="Clinica1", direccion="Dir", telefono="123", email="c1@example.com",
     )
     user = create_user_with_role_clinic(rol_user, clinica, email="user3@example.com")
     client.force_login(user)


### PR DESCRIPTION
## Summary
- implement stricter user registration via invitation
- enforce recaptcha check, unique email/phone and password policy
- allow cross-origin calls from localhost:3000
- add tests for new validation scenarios

## Testing
- `ruff check dentisoft/config/settings/base.py dentisoft/config/settings/local.py dentisoft/core/api/serializers.py dentisoft/core/tests/test_invitation_api.py`
- `pytest dentisoft/core/tests/test_invitation_api.py::test_invite_register_creates_user -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685a344c02508320808db13bdde18898